### PR TITLE
test: cover Event.get_id_from_code_year and --update edge cases

### DIFF
--- a/tests/test_database/test_database_events.py
+++ b/tests/test_database/test_database_events.py
@@ -112,6 +112,23 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(event.get_year(), "2024-01-01")
         self.assertEqual(event.get_country(), "USA")
 
+    def test_records_d_get_id_from_code_year_happy_path(self):
+        event = Event(event_code="trailx", event_name="Trail X", year="2023",
+                      country="ESP", db=self.db)
+        event.save_to_database()
+        event_id = Event.get_id_from_code_year("trailx", "2023", db=self.db)
+        self.assertEqual(event_id, event.get_event_id())
+
+    def test_records_e_get_id_from_code_year_wrong_year(self):
+        # "trailx" was saved with year 2023 in the previous test; querying a
+        # different year must not return the 2023 event_id.
+        event_id = Event.get_id_from_code_year("trailx", "2022", db=self.db)
+        self.assertIsNone(event_id)
+
+    def test_records_f_get_id_from_code_year_missing_code(self):
+        event_id = Event.get_id_from_code_year("phantom", "2023", db=self.db)
+        self.assertIsNone(event_id)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_db_LiveTrail_loader.py
+++ b/tests/test_db_LiveTrail_loader.py
@@ -38,11 +38,14 @@ class Testdb_LiveTrail_loader(unittest.TestCase):
 
     def test_get_years_only_in_v1_cold_start(self):
         # With an empty DB side (v2), the --update diff must surface every year
-        # from the scraper.
+        # from the scraper. get_years_only_in_v1 derives years via set
+        # difference so list ordering is not preserved — compare as sets.
         events, only_in_v1 = db_LiveTrail_loader.get_years_only_in_v1(
             self.events, self.years_v1, {})
         self.assertEqual(events, self.events)
-        self.assertEqual(only_in_v1, self.years_v1)
+        self.assertEqual(only_in_v1.keys(), self.years_v1.keys())
+        for code, expected_years in self.years_v1.items():
+            self.assertEqual(set(only_in_v1[code]), set(expected_years))
 
     def test_get_years_only_in_v1_fully_synced(self):
         # When scraper and DB are in sync, --update must produce nothing.

--- a/tests/test_db_LiveTrail_loader.py
+++ b/tests/test_db_LiveTrail_loader.py
@@ -35,3 +35,18 @@ class Testdb_LiveTrail_loader(unittest.TestCase):
 
         self.assertEqual(events, expected_events)
         self.assertEqual(only_in_v1, expected_years)
+
+    def test_get_years_only_in_v1_cold_start(self):
+        # With an empty DB side (v2), the --update diff must surface every year
+        # from the scraper.
+        events, only_in_v1 = db_LiveTrail_loader.get_years_only_in_v1(
+            self.events, self.years_v1, {})
+        self.assertEqual(events, self.events)
+        self.assertEqual(only_in_v1, self.years_v1)
+
+    def test_get_years_only_in_v1_fully_synced(self):
+        # When scraper and DB are in sync, --update must produce nothing.
+        events, only_in_v1 = db_LiveTrail_loader.get_years_only_in_v1(
+            self.events, self.years_v1, self.years_v1)
+        self.assertEqual(events, {})
+        self.assertEqual(only_in_v1, {})


### PR DESCRIPTION
Add three cases to TestEvent exercising the static lookup by (event_code, year): a happy path, a wrong-year lookup that must not fall back to an unrelated row, and a missing-code lookup.

Add two cases to the loader diff tests: cold-start (empty DB must surface every scraper year) and fully-synced (no year diff must produce no work).