### PR TITLE
feat: surface plots directory through config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 PACKAGE_DIR_PATH=/path/to/MLTrail
 # the data folder will have a folder named csv containing the downloaded results
 DATA_DIR_PATH=/path/to/MLTrail/data
+# defaults to {DATA_DIR_PATH}/plots if unset
+PLOTS_DIR_PATH=/path/to/MLTrail/data/plots
 
 # Optional configuration (defaults shown)
 # DB_FILENAME=events.db
 # MODEL_FILENAME=model.pkl
-# PLOTS_DIR=plots
 # LOG_LEVEL=INFO

--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,5 @@ DATA_DIR_PATH=/path/to/MLTrail/data
 # Optional configuration (defaults shown)
 # DB_FILENAME=events.db
 # MODEL_FILENAME=model.pkl
+# PLOTS_DIR=plots
 # LOG_LEVEL=INFO

--- a/front/pages/1_race_results.py
+++ b/front/pages/1_race_results.py
@@ -19,7 +19,7 @@ from auth import require_auth
 logger = logging.getLogger(__name__)
 
 cfg = get_config()
-DATA_DIR_PATH = cfg.data_dir_path
+PLOTS_DIR_PATH = cfg.plots_dir_path
 DB_PATH = cfg.db_path
 
 if not require_auth(DB_PATH):
@@ -115,7 +115,7 @@ def main():
 
             # Display analysis results
             if st.button('Generate Analysis'):
-                folder_path = os.path.join(DATA_DIR_PATH, 'plots', event)
+                folder_path = os.path.join(PLOTS_DIR_PATH, event)
                 if not os.path.exists(folder_path):
                     os.makedirs(folder_path)
                 file_path = os.path.join(folder_path, f'{event}_{race}_{year}.png')
@@ -150,7 +150,7 @@ def main():
             input_time = st.text_input('Enter Objective Time (HH:MM:SS):')
 
             if st.button('Set Objective'):
-                folder_path = os.path.join(DATA_DIR_PATH, 'plots', event)
+                folder_path = os.path.join(PLOTS_DIR_PATH, event)
                 if not os.path.exists(folder_path):
                     os.makedirs(folder_path)
                 try:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -12,9 +12,9 @@ class AppConfig:
     """Application configuration loaded from environment variables."""
     package_dir_path: str = ""
     data_dir_path: str = ""
+    plots_dir_path: str = ""
     db_filename: str = "events.db"
     model_filename: str = "model.pkl"
-    plots_dir: str = "plots"
     log_level: str = "INFO"
 
     @property
@@ -25,26 +25,25 @@ class AppConfig:
     def model_path(self) -> str:
         return os.path.join(self.data_dir_path, self.model_filename)
 
-    @property
-    def plots_dir_path(self) -> str:
-        # An absolute PLOTS_DIR lets users redirect plots outside DATA_DIR_PATH;
-        # a relative value keeps them co-located with the data.
-        return os.path.join(self.data_dir_path, self.plots_dir)
-
     @classmethod
     def from_env(cls) -> "AppConfig":
         load_dotenv(override=True)
+        data_dir_path = os.environ.get("DATA_DIR_PATH", "./data")
         config = cls(
             package_dir_path=os.environ.get("PACKAGE_DIR_PATH", "."),
-            data_dir_path=os.environ.get("DATA_DIR_PATH", "./data"),
+            data_dir_path=data_dir_path,
+            plots_dir_path=os.environ.get(
+                "PLOTS_DIR_PATH", os.path.join(data_dir_path, "plots")
+            ),
             db_filename=os.environ.get("DB_FILENAME", "events.db"),
             model_filename=os.environ.get("MODEL_FILENAME", "model.pkl"),
-            plots_dir=os.environ.get("PLOTS_DIR", "plots"),
             log_level=os.environ.get("LOG_LEVEL", "INFO"),
         )
         setup_logging(config.log_level)
-        logger.info("Config loaded: PACKAGE_DIR_PATH=%s, DATA_DIR_PATH=%s",
-                     config.package_dir_path, config.data_dir_path)
+        logger.info(
+            "Config loaded: PACKAGE_DIR_PATH=%s, DATA_DIR_PATH=%s, PLOTS_DIR_PATH=%s",
+            config.package_dir_path, config.data_dir_path, config.plots_dir_path,
+        )
         return config
 
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -14,6 +14,7 @@ class AppConfig:
     data_dir_path: str = ""
     db_filename: str = "events.db"
     model_filename: str = "model.pkl"
+    plots_dir: str = "plots"
     log_level: str = "INFO"
 
     @property
@@ -24,6 +25,12 @@ class AppConfig:
     def model_path(self) -> str:
         return os.path.join(self.data_dir_path, self.model_filename)
 
+    @property
+    def plots_dir_path(self) -> str:
+        # An absolute PLOTS_DIR lets users redirect plots outside DATA_DIR_PATH;
+        # a relative value keeps them co-located with the data.
+        return os.path.join(self.data_dir_path, self.plots_dir)
+
     @classmethod
     def from_env(cls) -> "AppConfig":
         load_dotenv(override=True)
@@ -32,6 +39,7 @@ class AppConfig:
             data_dir_path=os.environ.get("DATA_DIR_PATH", "./data"),
             db_filename=os.environ.get("DB_FILENAME", "events.db"),
             model_filename=os.environ.get("MODEL_FILENAME", "model.pkl"),
+            plots_dir=os.environ.get("PLOTS_DIR", "plots"),
             log_level=os.environ.get("LOG_LEVEL", "INFO"),
         )
         setup_logging(config.log_level)


### PR DESCRIPTION
Add AppConfig.plots_dir (env var PLOTS_DIR, default "plots") and a plots_dir_path property that joins it with data_dir_path. The race results page now pulls PLOTS_DIR_PATH from the config instead of concatenating 'plots' onto data_dir_path inline.

Behaviour is unchanged by default (plots still land in {DATA_DIR_PATH}/plots) and setting PLOTS_DIR to an absolute path now redirects plots outside the data directory.