### PR TITLE
feat: warn about prediction accuracy and data quantity

### DIFF
--- a/front/pages/1_race_results.py
+++ b/front/pages/1_race_results.py
@@ -186,6 +186,13 @@ def main():
 
             st.title('AI Time Predictions')
             if 'model_params' in st.session_state:
+                st.info(
+                    "Predictions are approximations extrapolated from your "
+                    "training races. They tend to be most useful on races "
+                    "with similar distance and elevation to those you've run "
+                    "before — more training data, and more varied profiles, "
+                    "typically lead to better estimates."
+                )
                 if st.button('Generate AI powered predictions'):
                     if st.session_state.model_params is not None:
                         with st.spinner('Loading race data...'):
@@ -206,6 +213,12 @@ def main():
                                 total_time = Features.format_time(float(results_cum.iloc[:-1]['PRED CUMUL'].values.sum()))
                                 data.loc[data['dist_total'] == data['dist_segment'], 'Prediction'] = total_time
                             st.write(data.drop(columns=['dist_total', 'elevation_pos_total', 'elevation_neg_total']))
+                            st.caption(
+                                "These numbers are estimates. Race-day "
+                                "conditions, terrain familiarity, and changes "
+                                "in fitness since your training data was "
+                                "collected can shift the actual outcome."
+                            )
             else:
                 st.write('Head to "my results" page to train an AI model on your data.')
 

--- a/front/pages/2_my_results.py
+++ b/front/pages/2_my_results.py
@@ -260,6 +260,11 @@ def _render_my_results_section(user_id):
 
 def _render_training_section(training_metadata):
     st.header("AI Model Training")
+    st.info(
+        "The model learns from the *Train*-checked rows above. Accuracy "
+        "improves with more races — and especially with races whose distance "
+        "and elevation profile resemble the races you want to predict."
+    )
     training_state = st.session_state.training_state
 
     # Already trained → show status + reset option.


### PR DESCRIPTION
Add three lightweight messages around AI prediction flows so users calibrate expectations:

- Training page: inline info before the train button explaining that more data, and more varied race profiles, yield better predictions.
- Race Results page: info banner above the "Generate predictions" button restating the accuracy caveat.
- Race Results page: caption under the prediction table noting that race-day conditions, terrain familiarity, and fitness drift can shift actual outcomes.