### PR TITLE
fix: spread consecutive NaNs linearly in Results.clean_times

### DIFF
--- a/src/results/results.py
+++ b/src/results/results.py
@@ -84,20 +84,20 @@ class Results:
                 if self.times.iloc[-1].isnull().any():
                     self.times = self.times.ffill(axis=axis)
         elif interpolate == 'mean':
-            df_ffilled = self.times.ffill(axis=axis)
-            if axis == 'rows':  # not tested
-                # First row may still contain NaN
-                if df_ffilled.iloc[0].isnull().any():
-                    df_ffilled = df_ffilled.bfill(axis=axis)
-            else:
-                if df_ffilled.iloc[:, 0].isnull().any():
-                    # First column may still contain NaN
-                    df_ffilled = df_ffilled.bfill(axis=axis)
-            df_ffilled = df_ffilled.map(self.get_seconds)
-            df_bfilled = self.times.bfill(axis=axis)
-            df_bfilled = df_bfilled.map(self.get_seconds)
-            self.times = (df_ffilled + df_bfilled) / 2
-            self.times = self.times.map(lambda x: self.get_time(self.offset + x))
+            # Linear interpolation between the nearest valid neighbours spreads
+            # consecutive NaNs proportionally. The previous (ffill+bfill)/2
+            # approach gave the same midpoint to every NaN in a run, producing
+            # duplicate timestamps whenever a runner missed two or more
+            # consecutive checkpoints (penyagolosa 2022 'mim' iloc[616]).
+            seconds = self.times.map(
+                lambda x: self.get_seconds(x) if isinstance(x, str) else np.nan
+            )
+            seconds = seconds.interpolate(method='linear', axis=axis,
+                                          limit_direction='both')
+            self.times = seconds.map(
+                lambda x: self.get_time(self.offset + x) if pd.notna(x)
+                else str(np.nan)
+            )
         return self.times
 
     def compute_real_times(self):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -384,6 +384,42 @@ class TestResults():
         ct.columns = list(sample_results.control_points.keys())
         assert all(ct == sample_results.clean_times())
 
+    def test_clean_times_multi_nan_run_spreads_linearly(self):
+        # Regression test: two consecutive NaNs on the same runner must be
+        # interpolated to distinct values (spread linearly between the
+        # bracketing valid times), not to the same midpoint. Pre-fix the
+        # 'mean' branch used (ffill+bfill)/2 which collapsed every NaN in a
+        # run onto the same value (penyagolosa 2022 'mim' iloc[616]).
+        control_points = {
+            'CP0': (0.0, 0, 0),
+            'CP1': (10.0, 100, -50),
+            'CP2': (20.0, 200, -100),
+            'CP3': (30.0, 300, -150),
+            'CP4': (40.0, 400, -200),
+        }
+        data = {
+            'CP0': ['00:00:00'],
+            'CP1': ['01:00:00'],
+            'CP2': [np.nan],
+            'CP3': [np.nan],
+            'CP4': ['04:00:00'],
+        }
+        times = pd.DataFrame(data, index=['1'])
+        control_points.pop(next(iter(control_points)))
+        rs = Results(control_points, times[control_points.keys()],
+                     offset='00:00:00', clean_days=False, start_day='1')
+        cp2 = rs.times.loc['1', 'CP2']
+        cp3 = rs.times.loc['1', 'CP3']
+        assert cp2 != cp3, (
+            f"Expected distinct interpolated values for consecutive NaNs, "
+            f"got CP2={cp2} CP3={cp3}"
+        )
+        # Between 01:00:00 (3600s) and 04:00:00 (14400s), linear interp at
+        # index positions 2 and 3 (between index 1 and 4) yields 7200 and
+        # 10800 → 02:00:00 and 03:00:00.
+        assert cp2 == '2:00:00'
+        assert cp3 == '3:00:00'
+
     def test_get_seconds(self, sample_results):
         assert sample_results.get_seconds('1:30:00') == 5397
         assert sample_results.get_seconds('3 days, 1:30:00') == 264597


### PR DESCRIPTION
The 'mean' interpolation branch built ffilled and bfilled copies of the times frame, converted them to seconds, and averaged them. For a run of N consecutive NaNs this produced the same midpoint for every gap — every missed checkpoint between two valid ones ended up with identical timestamps. Reproducible on penyagolosa 2022 'mim' iloc[616] where two adjacent NaNs both received the same interpolated time.

Replace the ffill+bfill average with a pandas linear interpolation on the seconds frame. Single-NaN gaps resolve to the same midpoint as before (preserving existing behaviour), and multi-NaN runs are now spread proportionally along the axis. Leading and trailing NaNs fall back to nearest valid via limit_direction='both'.

Add a regression test building a single runner whose middle two checkpoints are NaN and asserting the two interpolated timestamps are distinct and land on the expected linear positions.