### PR TITLE
feat: expose interpolated-cell mask on Results

### DIFF
--- a/src/results/results.py
+++ b/src/results/results.py
@@ -76,6 +76,12 @@ class Results:
             for c in empty_cols:
                 self.control_points.pop(c, None)
 
+        # Capture which cells will be filled by interpolation so callers
+        # (the front-end rendering code) can flag these cells as not real.
+        # Snapshotting here, after the DNF filter and all-NaN column drop
+        # but before any fill, gives a mask aligned to the final frame.
+        self.interpolated = self.times.isna()
+
         # prevent failing for df with only one row
         axis = 'columns' if len(self.times) == 1 else axis
         interpolate = 'mean' if len(self.times) == 1 else interpolate
@@ -112,6 +118,34 @@ class Results:
                 else str(np.nan)
             )
         return self.times
+
+    def get_interpolated_mask(self) -> pd.DataFrame:
+        '''
+            DataFrame of booleans, same shape / index / columns as ``self.times``.
+            ``True`` means the value at that cell was originally missing and
+            has been filled by ``clean_times``; front-end code can use this
+            to flag cells visually (e.g. appending an asterisk).
+            Returns an empty DataFrame if called before ``clean_times`` ran.
+        '''
+        if not hasattr(self, 'interpolated') or self.interpolated is None:
+            return pd.DataFrame()
+        return self.interpolated
+
+    def get_times_with_markers(self, marker: str = '*') -> pd.DataFrame:
+        '''
+            ``self.times`` with ``marker`` appended to every interpolated cell.
+            Handy for one-line rendering in the Streamlit pages without
+            having to style a separate DataFrame.
+        '''
+        mask = self.get_interpolated_mask()
+        if mask.empty:
+            return self.times.copy()
+        marked = self.times.copy()
+        for col in marked.columns:
+            if col in mask.columns:
+                col_mask = mask[col].reindex(marked.index, fill_value=False)
+                marked.loc[col_mask, col] = marked.loc[col_mask, col].astype(str) + marker
+        return marked
 
     def compute_real_times(self):
         first_cp_key, first_cp_value = list(self.control_points.items())[0]

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -452,6 +452,57 @@ class TestResults():
         assert cp2 == '2:00:00'
         assert cp3 == '3:00:00'
 
+    def test_get_interpolated_mask(self):
+        # Runner '1' has a NaN at CP2 that Results fills during clean_times;
+        # runner '2' has no missing values. The mask must reflect that.
+        control_points = {
+            'CP0': (0.0, 0, 0),
+            'CP1': (10.0, 100, -50),
+            'CP2': (20.0, 200, -100),
+            'CP3': (30.0, 300, -150),
+        }
+        data = {
+            'CP0': ['00:00:00', '00:00:00'],
+            'CP1': ['01:00:00', '01:00:00'],
+            'CP2': [np.nan,     '02:00:00'],
+            'CP3': ['03:00:00', '03:00:00'],
+        }
+        times = pd.DataFrame(data, index=['1', '2'])
+        control_points.pop(next(iter(control_points)))
+        rs = Results(control_points, times[control_points.keys()],
+                     offset='00:00:00', clean_days=False, start_day='1')
+
+        mask = rs.get_interpolated_mask()
+        assert bool(mask.loc['1', 'CP2']) is True
+        assert bool(mask.loc['2', 'CP2']) is False
+        for col in ('CP1', 'CP3'):
+            assert bool(mask.loc['1', col]) is False
+            assert bool(mask.loc['2', col]) is False
+
+    def test_get_times_with_markers(self):
+        control_points = {
+            'CP0': (0.0, 0, 0),
+            'CP1': (10.0, 100, -50),
+            'CP2': (20.0, 200, -100),
+            'CP3': (30.0, 300, -150),
+        }
+        data = {
+            'CP0': ['00:00:00', '00:00:00'],
+            'CP1': ['01:00:00', '01:00:00'],
+            'CP2': [np.nan,     '02:00:00'],
+            'CP3': ['03:00:00', '03:00:00'],
+        }
+        times = pd.DataFrame(data, index=['1', '2'])
+        control_points.pop(next(iter(control_points)))
+        rs = Results(control_points, times[control_points.keys()],
+                     offset='00:00:00', clean_days=False, start_day='1')
+
+        marked = rs.get_times_with_markers()
+        # Interpolated cell gets the marker; clean cells do not.
+        assert marked.loc['1', 'CP2'].endswith('*')
+        assert not marked.loc['1', 'CP1'].endswith('*')
+        assert not marked.loc['2', 'CP2'].endswith('*')
+
     def test_get_seconds(self, sample_results):
         assert sample_results.get_seconds('1:30:00') == 5397
         assert sample_results.get_seconds('3 days, 1:30:00') == 264597


### PR DESCRIPTION
Track which checkpoint timestamps were originally missing and filled in by clean_times, so the front-end can flag them as estimates instead of measurements.

Added:
- self.interpolated: DataFrame of booleans matching self.times, populated inside clean_times right after the DNF filter and all-NaN column drop (so the mask is aligned to the final frame).
- Results.get_interpolated_mask(): safe accessor that returns an empty frame if clean_times has not run yet.
- Results.get_times_with_markers(marker='*'): convenience that returns self.times with the marker appended to every interpolated cell; lets Streamlit pages render estimates with a single call.

Tests: one for the mask (interpolated cell True, real cells False) and one for the marker helper (asterisk on interpolated cells, not on real ones).