### PR TITLE
fix: do not wrap +24h on small backward step in Results

### DIFF
--- a/src/results/results.py
+++ b/src/results/results.py
@@ -31,14 +31,36 @@ class Results:
         self.paces = self.get_paces()
         self.paces_norm = self.get_paces_norm()
 
+    # Minimum backward step before we trust the +24h wrap. A genuine crossing
+    # of midnight produces a diff of ~22-24h; a spurious backward step from a
+    # bad interpolation is typically seconds to minutes, never more than an
+    # hour in practice. Clamping anything under this threshold prevents the
+    # interpolation glitch described in the README (trailnloue 2019 76km2j,
+    # 84th runner, just before the last checkpoint).
+    _WRAP_THRESHOLD_SECONDS = 3600
+
     def _correct_times24h(self, row) -> pd.Series:
         previous_time = row.iloc[0]
         adjusted_row = [row.iloc[0]]
-        adjusted_row = [row.iloc[0]]
-        for i, time in enumerate(row[1:]):            
-            if (self.get_seconds(time) ) < self.get_seconds(previous_time):
-                row.iloc[i+1:] = [self.get_time(self.get_seconds(t, offset=False) + 24 * 60 * 60) for t in row.iloc[i+1:]]
-                time = row.iloc[i+1]
+        for i, time in enumerate(row[1:]):
+            current_secs = self.get_seconds(time)
+            previous_secs = self.get_seconds(previous_time)
+            if current_secs < previous_secs:
+                gap = previous_secs - current_secs
+                if gap >= self._WRAP_THRESHOLD_SECONDS:
+                    # Genuine midnight wrap: add 24h to this and every later
+                    # checkpoint so the monotonic ordering is restored.
+                    row.iloc[i+1:] = [
+                        self.get_time(self.get_seconds(t, offset=False) + 24 * 60 * 60)
+                        for t in row.iloc[i+1:]
+                    ]
+                    time = row.iloc[i+1]
+                else:
+                    # Tiny backward step — almost certainly an interpolation
+                    # glitch. Clamp to the previous checkpoint so the +24h
+                    # correction further down the row is never triggered.
+                    time = previous_time
+                    row.iloc[i+1] = previous_time
             adjusted_row.append(time)
             previous_time = time
         return pd.Series(adjusted_row, index=row.index)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -452,6 +452,46 @@ class TestResults():
         assert cp2 == '2:00:00'
         assert cp3 == '3:00:00'
 
+    def test_interpolated_time_below_previous_does_not_wrap_24h(self):
+        # Regression test: when an interpolated checkpoint time ends up
+        # slightly below the previous one (the README mentions trailnloue
+        # 2019 76km2j, 84th runner, just before the last CP), the old
+        # _correct_times24h added 24h to every subsequent cell — producing
+        # nonsense like "24:52:30" instead of clamping to the previous
+        # checkpoint. Diffs under the 1h threshold must be treated as
+        # interpolation noise, not as a midnight wrap.
+        control_points = {
+            'CP0': (0.0, 0, 0),
+            'CP1': (5.0, 50, -20),
+            'CP2': (10.0, 100, -40),
+            'CP3': (15.0, 150, -60),
+            'CP4': (20.0, 200, -80),
+        }
+        # Runner '1' has NaN at CP2 bracketed by non-monotonic neighbours
+        # (CP1=01:00:00, CP3=00:45:00). Linear interpolation lands at
+        # 00:52:30, which is earlier than CP1 — the exact pattern that
+        # used to trigger the spurious +24h wrap. Runner '2' keeps the
+        # column alive so the all-NaN-column guard doesn't drop it.
+        data = {
+            'CP0': ['00:30:00', '00:30:00'],
+            'CP1': ['01:00:00', '01:00:00'],
+            'CP2': [np.nan,     '01:20:00'],
+            'CP3': ['00:45:00', '01:30:00'],
+            'CP4': ['03:00:00', '03:00:00'],
+        }
+        times = pd.DataFrame(data, index=['1', '2'])
+        control_points.pop(next(iter(control_points)))
+        rs = Results(control_points, times[control_points.keys()],
+                     offset='00:00:00', clean_days=False, start_day='1')
+
+        # No cell should have been pushed past 24h — the former behaviour
+        # wrapped the row's tail to "24:..." / "1 day, ...".
+        for col in rs.times.columns:
+            v = rs.times.loc['1', col]
+            assert 'day' not in v, f"{col}={v!r} crossed 24h"
+            h = int(v.split(':')[0])
+            assert h < 24, f"{col}={v!r} has h>=24"
+
     def test_get_seconds(self, sample_results):
         assert sample_results.get_seconds('1:30:00') == 5397
         assert sample_results.get_seconds('3 days, 1:30:00') == 264597

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -478,6 +478,20 @@ class TestResults():
             'CP2': [np.nan,     '01:20:00'],
             'CP3': ['00:45:00', '01:30:00'],
             'CP4': ['03:00:00', '03:00:00'],
+        }
+        times = pd.DataFrame(data, index=['1', '2'])
+        control_points.pop(next(iter(control_points)))
+        rs = Results(control_points, times[control_points.keys()],
+                     offset='00:00:00', clean_days=False, start_day='1')
+
+        # No cell should have been pushed past 24h — the former behaviour
+        # wrapped the row's tail to "24:..." / "1 day, ...".
+        for col in rs.times.columns:
+            v = rs.times.loc['1', col]
+            assert 'day' not in v, f"{col}={v!r} crossed 24h"
+            h = int(v.split(':')[0])
+            assert h < 24, f"{col}={v!r} has h>=24"
+
     def test_get_interpolated_mask(self):
         # Runner '1' has a NaN at CP2 that Results fills during clean_times;
         # runner '2' has no missing values. The mask must reflect that.
@@ -498,13 +512,6 @@ class TestResults():
         rs = Results(control_points, times[control_points.keys()],
                      offset='00:00:00', clean_days=False, start_day='1')
 
-        # No cell should have been pushed past 24h — the former behaviour
-        # wrapped the row's tail to "24:..." / "1 day, ...".
-        for col in rs.times.columns:
-            v = rs.times.loc['1', col]
-            assert 'day' not in v, f"{col}={v!r} crossed 24h"
-            h = int(v.split(':')[0])
-            assert h < 24, f"{col}={v!r} has h>=24"
         mask = rs.get_interpolated_mask()
         assert bool(mask.loc['1', 'CP2']) is True
         assert bool(mask.loc['2', 'CP2']) is False


### PR DESCRIPTION
_correct_times24h walked each runner's checkpoint row left-to-right and whenever the current timestamp fell below the previous one, it added 24 hours to that cell and every cell after it. The heuristic works for genuine crossings of midnight on ultra races, but an interpolated NaN bracketed by non-monotonic neighbours can land just below the previous checkpoint — and the fix-up would then promote the rest of the row to "24:..." / "1 day, ..." (reported in the README against trailnloue 2019 76km2j, 84th runner, before the last CP).

Split the two cases with a 1-hour threshold: a real midnight wrap produces a backward jump of ~22-24h, so anything under an hour is treated as interpolation noise and clamped to the previous checkpoint instead. Add a regression test constructing the exact pattern (NaN bracketed by non-monotonic values) and asserting no cell is pushed past the 24h mark.