### PR TITLE
feat: surface interpolated times in race results page

### DIFF
--- a/front/pages/1_race_results.py
+++ b/front/pages/1_race_results.py
@@ -58,6 +58,22 @@ def get_results(event, year, race):
     return raw_results, control_points, rs, race_info, waves
 
 
+def apply_interpolation_markers(df, mask, marker: str = '*'):
+    '''
+    Append ``marker`` to every cell of ``df`` whose corresponding entry in
+    ``mask`` is True. The mask is sourced from Results.get_interpolated_mask()
+    and has the same shape/index/columns as the times frames.
+    '''
+    if mask is None or mask.empty:
+        return df
+    out = df.copy()
+    for col in out.columns:
+        if col in mask.columns:
+            col_mask = mask[col].reindex(out.index, fill_value=False)
+            out.loc[col_mask, col] = out.loc[col_mask, col].astype(str) + marker
+    return out
+
+
 def clean_events(events: dict) -> dict:
     '''
         Clean special characters, repeated names etc. from the events list
@@ -132,15 +148,26 @@ def main():
                 }
                 st.session_state.race_info = race_info
                 # Display data
+                interp_mask = rs.get_interpolated_mask()
+                has_interp = not interp_mask.empty and bool(interp_mask.values.any())
+                if has_interp:
+                    st.caption(
+                        "`*` marks times that were interpolated from "
+                        "neighbouring checkpoints because the runner's "
+                        "actual time was missing. Treat them as estimates."
+                    )
                 st.write(f"Departure time: {race_info['hd']}")
                 st.write('Hours:')
-                st.write(data['hours'].sort_index())
+                st.write(apply_interpolation_markers(
+                    data['hours'].sort_index(), interp_mask))
 
                 st.write('Official Times:')
-                st.write(data['real_times'].sort_index())
+                st.write(apply_interpolation_markers(
+                    data['real_times'].sort_index(), interp_mask))
                 if waves:
                     st.write('Real Times:')
-                    st.write(data['real_times'].sort_index())
+                    st.write(apply_interpolation_markers(
+                        data['real_times'].sort_index(), interp_mask))
 
                 st.write('Paces:')
                 st.write(data['paces'].sort_index())


### PR DESCRIPTION
Pull the mask from Results.get_interpolated_mask() and post-process the displayed Hours / Official Times / Real Times tables so cells that were filled by clean_times get an asterisk suffix. A caption appears above the tables only when at least one cell was interpolated, so races with complete timing don't display noise.

Paces are left untouched: they are derived from interpolated times and would all carry an asterisk on incomplete races, which is visually overwhelming. The asterisk on the time tables is enough to let the user trace where estimates come from.