### PR TITLE
Feat/backfill categories from coureur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ examples/*.ipynb
 !front/*
 !front/pages/
 !front/pages/*
+!scripts/
+!scripts/*
 !data/
 !data/csv/
 !data/csv/transgrancanaria/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,47 @@ Same syntax and options apply to To recompute the `Timing_points` table and scri
 More details and visual example in the notebook `examples/parse_LiveTrail_to_DB.ipynb`
 
 
+## Backfilling missing categories
+
+Some events (the Spanish 2025+ cluster — Penyagolosa, Olla de Núria, Epic Trail Costa Daurada — and a longer tail of chronic-empty races like `seoul100k`, `tnfkorea`, `3monestirs`, etc.) do not publish the `cat` attribute in LiveTrail's bulk `passages.php` XML. The per-runner `coureur.php` endpoint still exposes `sx` (sex) and sometimes `descat` (age bracket), so `src/database/loader_LiveTrail/backfill_categories.py` recovers what it can.
+
+It runs automatically for the events a loader touches:
+
+```bash
+python -m database.loader_LiveTrail.db_LiveTrail_loader --update
+```
+
+It can also be run as a one-shot sweep over the whole DB:
+
+```bash
+python -m database.loader_LiveTrail.backfill_categories
+```
+
+```
+options:
+  -p, --path PATH          DB path (default: the configured events.db).
+  -t, --threshold FLOAT    Empty-cat ratio that flags a race (default 0.10).
+  --event-id INT           Restrict to one or more event_ids (repeatable).
+  --log PATH               Progress log file (default: backfill.log).
+```
+
+The run is idempotent: races whose rows have already been filled are skipped. `backfill.log` records every completed race with `Backfilled <event> <year> <race>: attempted=N updated=M`, which `scripts/resume_backfill.py` uses to continue after an interruption:
+
+```bash
+python scripts/resume_backfill.py --path data/events.db --log backfill.log
+```
+
+```
+options:
+  --skip event[:year[:race]]   Short-circuit races LiveTrail cannot serve
+                               (e.g. `--skip marxainfantil:2025`). Repeatable.
+  --dry-run                    Print the plan without making any HTTP calls.
+```
+
+The resume helper writes to `backfill_resume.log` in the same line format so chained recoveries (crash → resume → crash → resume) do not lose state.
+
+
+
 > :warning: **Warning:** Changing paths in scripts through the `-p` or `data-path` options is discouraged. Advanced users only.
 
 # Collaborating

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ Don't hesitate to get in contact or open an issue!
 - [ ] *Tablelize* countries, categories.
 - [X] Add tests.
 - [ ] Add logic to control creation of objects (manage nullable or not fields) --> Seems impossible with old races
-- [ ] Add Events getid to tests
-- [ ] Add update race case into tests
+- [X] Add Events getid to tests
+- [X] Add update race case into tests
 - [X] Add Events to db
 - [X] Add Races to DB
 - [X] Need to reload races to DB due to identified bug (2696 from 3333 have a NULL departure_racetime)
@@ -160,7 +160,7 @@ Don't hesitate to get in contact or open an issue!
 - [X] Load results to DB
 - [X] Compute category results in DB
 - [X] Design a way of having passing times in DB and not only final times
-- [ ] Fix path for data and plots (env variable) --> data done, TODO: plots
+- [X] Fix path for data and plots (env variable)
 - [X] Not sure: Departure time doesn't seem always correct, will have to figure out another way of parsing it
 - [X] add add Scraper.getRacesPhysicalDetails, Scraper.getRandomRunnerBib to tests
 - [X] add results download + load to DB to lib instead of notebook + script
@@ -187,11 +187,11 @@ Don't hesitate to get in contact or open an issue!
 - [ ] Show race profile from distance, D+ and D- data? Maybe too aproximative and need real gps data
 - [ ] Objective graph is only paces, show times / normalised pace?
 - [X] Bug when races include departure time in timing_points file
-- [ ] Add Warinings about prediction methods not being accurate, and that more data usually shows better results.
+- [X] Add Warinings about prediction methods not being accurate, and that more data usually shows better results.
 - [ ] Migrate to a more powerful technology (Node?)
 
 ### BackEnd
-- [ ] BUG: (minor) Results class, if there are more than 1 NaN in a row, the interpolated time is the same for all of them when performing the mean (e.g. penyagolosa 2022 'mim': iloc[616] has 2 NaN in a row)
+- [X] BUG: (minor) Results class, if there are more than 1 NaN in a row, the interpolated time is the same for all of them when performing the mean (e.g. penyagolosa 2022 'mim': iloc[616] has 2 NaN in a row)
 - [ ] BUG: Results class cannot handle a full column of NaN. We should delete the control point (e.g. mut 2023)
 - [X] BUG: Results class cannot handle 2 control points with the same distance. (e.g. trailnloue 2019 - 76km2j)
 - [X] BUGs: Results class. Mostly cancelled races.

--- a/scripts/resume_backfill.py
+++ b/scripts/resume_backfill.py
@@ -1,0 +1,321 @@
+"""One-shot resume for `database.loader_LiveTrail.backfill_categories`.
+
+The original backfill run against events.db:
+  * processed ~25 flagged races fully,
+  * hit 3/3 retry failures on a handful of individual bibs (DNS drops during
+    a LiveTrail window),
+  * ended up crashing on ``sqlite3.OperationalError: database is locked``
+    midway through the list,
+
+so a good chunk of flagged races were never visited at all and a small
+fraction of bibs inside completed races still have empty categories.
+
+This script is a **one-shot** recovery run. It:
+
+  1. Parses the existing ``backfill.log`` (or whatever file you point it at
+     via ``--log``) to see which races finished, and which bibs failed 3/3
+     so we can note them in the resume log.
+  2. Queries the DB for the **actual** remaining work per flagged race —
+     ``sex_category IS NULL`` is the truthy "this bib never got a coureur.php
+     hit" signal, because even chronic-empty events (where descat is blank)
+     get ``sex_category`` populated on a successful backfill while
+     ``full_category`` stays empty.
+  3. Iterates flagged races in order, skipping those with zero remaining
+     bibs, and calling ``get_runner_identity`` for the ones still missing.
+
+The script is idempotent: running it again after another interruption will
+pick up exactly where it left off. It writes its own progress log to
+``backfill_resume.log`` so the original log is not clobbered.
+
+Usage::
+
+    PYTHONPATH=src python scripts/resume_backfill.py \\
+        --path data/events.db \\
+        --log backfill.log
+
+Options are the same as the main backfill CLI plus ``--log`` and ``--dry-run``.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from database.loader_LiveTrail.backfill_categories import (  # noqa: E402
+    DEFAULT_EMPTY_CAT_THRESHOLD,
+    _full_category_from_identity,
+    _recompute_cat_rankings_for_race,
+    _sex_category_from_sx,
+    list_flagged_races,
+)
+from database.create_db import Database  # noqa: E402
+from scraper.scraper import LiveTrailScraper  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# Parses a "Backfilled penyagolosa 2025 mim: attempted=273 updated=273" line.
+BACKFILL_RE = re.compile(
+    r"Backfilled\s+(\S+)\s+(\S+)\s+(\S+):\s+attempted=(\d+)\s+updated=(\d+)"
+)
+# Parses "Request failed after 3 retries: https://livetrail.net/histo/<ev>_<yr>/coureur.php?rech=<bib>"
+# Two URL shapes exist: "<event>_<year>" and "<event><year>".
+FAILED_RE = re.compile(
+    r"Request failed after 3 retries:\s+"
+    r"https://livetrail\.net/histo/(?P<slug>[A-Za-z0-9]+?)_?(?P<year>\d{4})/"
+    r"coureur\.php\?rech=(?P<bib>\S+)"
+)
+
+
+def parse_backfill_log(log_path: str) -> tuple[set[tuple[str, str, str]],
+                                                dict[tuple[str, str], set[str]]]:
+    """Return ``(completed_races, failed_bibs)`` from a prior run's log.
+
+    ``completed_races`` is a set of ``(event_code, year, race_id)`` triples
+    seen in "Backfilled ... attempted=N updated=M" lines — regardless of
+    whether N == M, because the DB-level "still has empty category" check
+    below tells us exactly which bibs are genuinely still open.
+
+    ``failed_bibs`` is keyed by ``(event_code, year)`` and collects the bibs
+    LiveTrail refused after 3 retries. We surface these in the resume log
+    so the user can see what was physically unreachable versus what was
+    just not attempted yet.
+    """
+    completed: set[tuple[str, str, str]] = set()
+    failed: dict[tuple[str, str], set[str]] = defaultdict(set)
+
+    if not os.path.exists(log_path):
+        logger.warning("Log %s not found — nothing to parse.", log_path)
+        return completed, failed
+
+    with open(log_path, "r", encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            m = BACKFILL_RE.search(line)
+            if m:
+                completed.add((m.group(1), m.group(2), m.group(3)))
+                continue
+            m = FAILED_RE.search(line)
+            if m:
+                key = (m.group("slug"), m.group("year"))
+                failed[key].add(m.group("bib"))
+
+    return completed, failed
+
+
+def fetch_pending_bibs(db_path: str, event_id: int, race_id: str) -> list[str]:
+    """Bibs that still need a coureur.php hit.
+
+    ``sex_category IS NULL`` is the authoritative signal: the first
+    successful call to ``get_runner_identity`` on a bib always writes a
+    sex_category value (H→Male, F→Female). If it's still NULL, the bib
+    was either never attempted or failed all retries. ``full_category``
+    can legitimately remain empty on chronic-empty events, so filtering
+    only on it would re-hit every already-processed row on those events.
+    """
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT bib FROM results
+            WHERE event_id = ? AND race_id = ?
+              AND sex_category IS NULL
+              AND (full_category IS NULL OR full_category = '')
+            """,
+            (event_id, race_id),
+        )
+        return [row[0] for row in cursor.fetchall() if row[0]]
+    finally:
+        conn.close()
+
+
+def apply_identity(db_path: str, event_id: int, race_id: str,
+                   bib: str, identity: dict) -> bool:
+    """Write the derived sex / full category to the results row.
+
+    Returns True when the row was updated with at least one of the two
+    columns. COALESCE protects existing values from being clobbered by
+    nulls in the identity payload.
+    """
+    sex_cat = _sex_category_from_sx(identity.get("sx", ""))
+    full_cat = _full_category_from_identity(identity)
+    if sex_cat is None and full_cat is None:
+        return False
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE results
+            SET sex_category = COALESCE(?, sex_category),
+                full_category = COALESCE(NULLIF(?, ''), full_category)
+            WHERE event_id = ? AND race_id = ? AND bib = ?
+            """,
+            (sex_cat, full_cat, event_id, race_id, bib),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return True
+
+
+def resume_race(scraper: LiveTrailScraper, db_path: str,
+                event_id: int, race_id: str, event_code: str, year: str,
+                pending_bibs: list[str]) -> tuple[int, int]:
+    """Retry the given bibs for one race. Returns ``(attempted, updated)``."""
+    attempted = 0
+    updated = 0
+    for bib in pending_bibs:
+        if not bib:
+            continue
+        attempted += 1
+        identity = scraper.get_runner_identity(event_code, year, bib)
+        if identity is None:
+            continue
+        if apply_identity(db_path, event_id, race_id, bib, identity):
+            updated += 1
+    if updated:
+        _recompute_cat_rankings_for_race(db_path, event_id, race_id)
+    return attempted, updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Resume a previous backfill_categories run where it left off."
+    )
+    parser.add_argument("-p", "--path", required=True, help="DB path.")
+    parser.add_argument("-l", "--log", default="backfill.log",
+                        help="Path to the prior run's log file.")
+    parser.add_argument("-t", "--threshold", type=float,
+                        default=DEFAULT_EMPTY_CAT_THRESHOLD,
+                        help="Empty-cat ratio for the detector "
+                             f"(default {DEFAULT_EMPTY_CAT_THRESHOLD}).")
+    parser.add_argument("--event-id", type=int, action="append",
+                        help="Restrict to one or more event_ids (may be repeated).")
+    parser.add_argument("--skip", action="append", default=[],
+                        help="Skip a race spelled 'event_code[:year[:race_id]]'. "
+                             "May be repeated. Examples: '--skip marxainfantil' "
+                             "skips every marxainfantil year/race; "
+                             "'--skip marxainfantil:2025' skips all marxainfantil "
+                             "2025 races; '--skip marxainfantil:2025:marxa' skips "
+                             "just that one race.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the plan without issuing any HTTP calls.")
+    args = parser.parse_args()
+
+    # Parse --skip into a list of (code, year_or_None, race_or_None) tuples.
+    skip_rules: list[tuple[str, str | None, str | None]] = []
+    for raw in args.skip:
+        parts = raw.split(":")
+        if len(parts) == 1:
+            skip_rules.append((parts[0], None, None))
+        elif len(parts) == 2:
+            skip_rules.append((parts[0], parts[1], None))
+        elif len(parts) == 3:
+            skip_rules.append((parts[0], parts[1], parts[2]))
+        else:
+            parser.error(f"--skip takes at most 3 colon-separated fields: {raw!r}")
+
+    def is_skipped(code: str, year: str, race_id: str) -> bool:
+        for c, y, r in skip_rules:
+            if c != code:
+                continue
+            if y is not None and y != year:
+                continue
+            if r is not None and r != race_id:
+                continue
+            return True
+        return False
+
+    # Keep the resume output separate from the original backfill.log so
+    # you can diff timelines if needed.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler("backfill_resume.log", encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+    )
+
+    db_path = os.path.abspath(args.path)
+    logger.info("Resuming against %s (log: %s)", db_path, args.log)
+
+    # Ensure migration has been applied (idempotent).
+    Database.ensure_cat_backfill_column(db_path)
+
+    completed, failed_bibs = parse_backfill_log(args.log)
+    logger.info("Log summary: %d races reported completed, "
+                "%d (event,year) pairs with failed bibs (total %d failed bibs).",
+                len(completed), len(failed_bibs),
+                sum(len(b) for b in failed_bibs.values()))
+
+    flagged = list_flagged_races(db_path, event_ids=args.event_id)
+    logger.info("Flagged races in DB: %d", len(flagged))
+
+    # Build the work plan: for every flagged race, query the DB for the
+    # actual pending bibs. This is what matters — the log only hints at
+    # what happened, the DB is the source of truth for what's still open.
+    plan: list[tuple[int, str, str, str, list[str]]] = []
+    skipped_count = 0
+    for event_id, race_id, event_code, year in flagged:
+        if is_skipped(event_code, year, race_id):
+            skipped_count += 1
+            logger.info("Skipping %s %s %s (matched --skip rule)",
+                        event_code, year, race_id)
+            continue
+        pending = fetch_pending_bibs(db_path, event_id, race_id)
+        if pending:
+            plan.append((event_id, race_id, event_code, year, pending))
+
+    total_pending = sum(len(p[4]) for p in plan)
+    logger.info("Resume plan: %d race(s) with pending bibs, %d bibs total.",
+                len(plan), total_pending)
+
+    if args.dry_run:
+        for event_id, race_id, event_code, year, pending in plan[:50]:
+            fail_key = (event_code, year)
+            prior_failed = len(failed_bibs.get(fail_key, set()))
+            already_completed = (event_code, year, race_id) in completed
+            logger.info(
+                "  [%s %s %s] pending=%d prior_failed_in_log=%d already_logged_done=%s",
+                event_code, year, race_id, len(pending), prior_failed,
+                already_completed,
+            )
+        if len(plan) > 50:
+            logger.info("  ... and %d more races", len(plan) - 50)
+        logger.info("Dry run — no HTTP calls made.")
+        return
+
+    scraper = LiveTrailScraper()
+    total_updated = 0
+    for event_id, race_id, event_code, year, pending in plan:
+        logger.info("Resuming %s %s %s (%d pending bibs)...",
+                    event_code, year, race_id, len(pending))
+        attempted, updated = resume_race(
+            scraper, db_path, event_id, race_id, event_code, year, pending,
+        )
+        total_updated += updated
+        # Match the "Backfilled ... attempted=N updated=M" format emitted by
+        # database.loader_LiveTrail.backfill_categories so this resume log
+        # is itself re-parseable by another pass of this script if the
+        # resume run also gets interrupted.
+        logger.info("Backfilled %s %s %s: attempted=%d updated=%d",
+                    event_code, year, race_id, attempted, updated)
+
+    logger.info("Resume finished: %d row(s) updated across %d race(s).",
+                total_updated, len(plan))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/database/create_db.py
+++ b/src/database/create_db.py
@@ -62,7 +62,9 @@ class Database:
             )
         ''')
 
-        # Create races table
+        # Create races table. cat_needs_backfill flags races whose category
+        # data is absent or partial in LiveTrail's bulk XML and must be
+        # recovered per-runner from coureur.php.
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS races (
                 race_id TEXT,
@@ -73,6 +75,7 @@ class Database:
                 elevation_neg INTEGER,
                 departure_datetime TEXT,
                 results_filepath TEXT,
+                cat_needs_backfill INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (race_id, event_id),
                 FOREIGN KEY (event_id) REFERENCES events(event_id)
             )
@@ -179,6 +182,32 @@ class Database:
         logger.info("Database created successfully at %s", cls.path)
 
         return cls
+
+    @classmethod
+    def ensure_cat_backfill_column(cls, path=None) -> None:
+        '''
+            Idempotent migration: add races.cat_needs_backfill if it is missing.
+
+            Older DBs predate the scraped-category-gap feature; SQLite does not
+            support `ADD COLUMN IF NOT EXISTS`, so inspect pragma first.
+        '''
+        if path:
+            cls.path = path
+        try:
+            conn = sqlite3.connect(cls.path)
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA table_info(races)")
+            existing = {row[1] for row in cursor.fetchall()}
+            if 'cat_needs_backfill' not in existing:
+                cursor.execute(
+                    "ALTER TABLE races ADD COLUMN "
+                    "cat_needs_backfill INTEGER NOT NULL DEFAULT 0"
+                )
+                conn.commit()
+                logger.info("Added races.cat_needs_backfill column")
+            conn.close()
+        except sqlite3.Error as e:
+            logger.error("Error ensuring cat_needs_backfill column: %s", e)
 
     @classmethod
     def ensure_user_results_table(cls, path=None) -> None:

--- a/src/database/loader_LiveTrail/CSV_to_DB_results.py
+++ b/src/database/loader_LiveTrail/CSV_to_DB_results.py
@@ -121,7 +121,11 @@ def format_timedelta(td):
 
 
 def update_category(cursor, event_id):
-    # Set category
+    # Derive sex_category from the full_category suffix. Skip rows where
+    # sex_category is already populated: the backfill pipeline writes it
+    # directly from coureur.php for rows where LiveTrail's bulk XML dropped
+    # the cat attribute, and we don't want to clobber that value on
+    # subsequent loader runs where full_category is still empty.
     cursor.execute('''
                     UPDATE results
                     SET sex_category =
@@ -133,6 +137,7 @@ def update_category(cursor, event_id):
                         ELSE NULL
                     END
                     WHERE event_id = ?
+                      AND sex_category IS NULL
                     ''', (event_id,)
                    )
 

--- a/src/database/loader_LiveTrail/backfill_categories.py
+++ b/src/database/loader_LiveTrail/backfill_categories.py
@@ -298,7 +298,25 @@ def main() -> None:
         '--event-id', type=int, action='append',
         help='Restrict to one or more event_ids (may be repeated).',
     )
+    parser.add_argument(
+        '--log', default='backfill.log',
+        help="Path to the log file (default 'backfill.log'). Complements "
+             "stdout — having the file is what lets the resume script "
+             "figure out where a crashed run left off.",
+    )
     args = parser.parse_args()
+
+    # Add a file handler so every 'Backfilled ...' / 'Flagged ...' line is
+    # captured on disk, regardless of how the user launched the script.
+    # Do this in addition to whatever stream handler setup_logging (called
+    # via get_config) already configured, not as a replacement.
+    file_handler = logging.FileHandler(args.log, encoding='utf-8')
+    file_handler.setFormatter(logging.Formatter(
+        '%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+    ))
+    logging.getLogger().addHandler(file_handler)
+    logger.info("Logging to %s", os.path.abspath(args.log))
+
     backfill_all(
         db_path=os.path.abspath(args.path),
         event_ids=args.event_id,

--- a/src/database/loader_LiveTrail/backfill_categories.py
+++ b/src/database/loader_LiveTrail/backfill_categories.py
@@ -1,0 +1,310 @@
+"""Backfill missing category data for races where LiveTrail's bulk XML omits it.
+
+Some organizers stopped serialising the ``cat`` attribute in ``passages.php``
+for a subset of runners (the Spanish cluster — Penyagolosa, Olla de Núria,
+Epic Trail Costa Daurada — dropped the SE/<35 bracket starting 2025; a longer
+tail of events, mostly Asian ultras and mass-participation races, never
+published categories at all). The per-runner ``coureur.php`` endpoint still
+exposes ``sx`` (H/F) and sometimes ``descat`` (the age bracket), so we can
+recover at least the sex, and when ``descat`` is present a full category
+label as well.
+
+Detection: for every race in the DB, count rows with NULL/empty
+``full_category``. If the ratio crosses a threshold we set
+``races.cat_needs_backfill = 1``; the flag persists so future loader runs
+know to re-apply the backfill when they see new data for that race.
+
+Backfill: for every flagged race, fetch ``coureur.php`` per empty-cat bib,
+update ``results.sex_category`` directly (H → Male, F → Female) and
+``results.full_category`` when ``descat`` is available, then recompute
+category rankings for the race.
+"""
+import argparse
+import logging
+import os
+import sqlite3
+from typing import Iterable
+
+from config import get_config
+from database.create_db import Database
+from scraper.scraper import LiveTrailScraper
+
+logger = logging.getLogger(__name__)
+
+# Ratio of empty-cat rows above which a race is considered "needs backfill".
+# Asian/mass-participation events that never publish categories sit at or near
+# 100%; the Spanish 2025+ cluster hovers in the 15-30% range. 10% is low enough
+# to catch both without snagging UTMB-style races whose baseline is <0.5%.
+DEFAULT_EMPTY_CAT_THRESHOLD = 0.10
+
+_SEX_MAP = {'F': 'Female', 'H': 'Male', 'M': 'Male'}
+
+
+def _sex_category_from_sx(sx: str) -> str | None:
+    return _SEX_MAP.get((sx or '').upper())
+
+
+def _full_category_from_identity(identity: dict) -> str | None:
+    """Rebuild a ``full_category`` string from ``descat`` + ``sx``.
+
+    Returns ``None`` when ``descat`` is empty — the caller should leave
+    ``full_category`` alone in that case, since we have no age bracket to
+    publish even if we know the runner's sex.
+    """
+    descat = (identity.get('descat') or '').strip()
+    sx = (identity.get('sx') or '').strip().upper()
+    if not descat:
+        return None
+    suffix = 'F' if sx == 'F' else 'H' if sx in ('H', 'M') else ''
+    # "0-34 F" rather than "0-34F" keeps it visually close to the existing
+    # "- F" / "MA30H" shapes the DB has for older penyagolosa rows.
+    return f"{descat} {suffix}".strip()
+
+
+def _open(db_path: str) -> sqlite3.Connection:
+    return sqlite3.connect(db_path, timeout=30)
+
+
+def detect_races_needing_backfill(
+    db_path: str,
+    threshold: float = DEFAULT_EMPTY_CAT_THRESHOLD,
+) -> list[tuple[int, str, float]]:
+    """Scan every race and flag those exceeding the empty-cat ratio.
+
+    Returns the list of ``(event_id, race_id, ratio)`` tuples that were
+    newly flagged this run (rows that were already flagged are not returned
+    again, so the caller can log only the deltas).
+    """
+    Database.ensure_cat_backfill_column(db_path)
+    conn = _open(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT r.event_id, r.race_id, r.cat_needs_backfill,
+                   COUNT(*) AS total,
+                   SUM(CASE WHEN res.full_category IS NULL
+                                 OR res.full_category = ''
+                            THEN 1 ELSE 0 END) AS empty_cat
+            FROM races r
+            INNER JOIN results res
+                ON res.event_id = r.event_id AND res.race_id = r.race_id
+            GROUP BY r.event_id, r.race_id
+        ''')
+        newly_flagged = []
+        for event_id, race_id, already_flagged, total, empty in cursor.fetchall():
+            if total == 0:
+                continue
+            ratio = empty / total
+            if ratio >= threshold and not already_flagged:
+                cursor.execute(
+                    "UPDATE races SET cat_needs_backfill = 1 "
+                    "WHERE event_id = ? AND race_id = ?",
+                    (event_id, race_id),
+                )
+                newly_flagged.append((event_id, race_id, ratio))
+        conn.commit()
+        return newly_flagged
+    finally:
+        conn.close()
+
+
+def list_flagged_races(
+    db_path: str,
+    event_ids: Iterable[int] | None = None,
+) -> list[tuple[int, str, str, str]]:
+    """Return ``(event_id, race_id, event_code, year)`` for flagged races.
+
+    Optionally restrict to a subset of ``event_ids`` so loaders can process
+    only what they just touched during an ``--update`` run.
+    """
+    conn = _open(db_path)
+    try:
+        cursor = conn.cursor()
+        params: list = []
+        query = '''
+            SELECT r.event_id, r.race_id, e.code, e.year
+            FROM races r
+            INNER JOIN events e ON e.event_id = r.event_id
+            WHERE r.cat_needs_backfill = 1
+        '''
+        if event_ids is not None:
+            ids = list(event_ids)
+            if not ids:
+                return []
+            query += f" AND r.event_id IN ({','.join('?' * len(ids))})"
+            params.extend(ids)
+        query += ' ORDER BY e.year DESC, e.code, r.race_id'
+        cursor.execute(query, params)
+        return cursor.fetchall()
+    finally:
+        conn.close()
+
+
+def backfill_race(
+    scraper: LiveTrailScraper,
+    db_path: str,
+    event_id: int,
+    race_id: str,
+    event_code: str,
+    year: str,
+) -> tuple[int, int]:
+    """Fetch per-runner identity for every empty-cat bib in the race.
+
+    Returns ``(attempted, updated)`` so the caller can log progress.
+    """
+    conn = _open(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            SELECT bib FROM results
+            WHERE event_id = ? AND race_id = ?
+              AND (full_category IS NULL OR full_category = '')
+            ''',
+            (event_id, race_id),
+        )
+        bibs = [row[0] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+    attempted = 0
+    updated = 0
+    for bib in bibs:
+        if not bib:
+            continue
+        attempted += 1
+        identity = scraper.get_runner_identity(event_code, year, bib)
+        if identity is None:
+            continue
+        sex_cat = _sex_category_from_sx(identity.get('sx', ''))
+        full_cat = _full_category_from_identity(identity)
+        if sex_cat is None and full_cat is None:
+            continue
+        conn = _open(db_path)
+        try:
+            cursor = conn.cursor()
+            # COALESCE keeps any non-null existing value we may not want to
+            # overwrite if the result row has been partially populated.
+            cursor.execute(
+                '''
+                UPDATE results
+                SET sex_category = COALESCE(?, sex_category),
+                    full_category = COALESCE(NULLIF(?, ''), full_category)
+                WHERE event_id = ? AND race_id = ? AND bib = ?
+                ''',
+                (sex_cat, full_cat, event_id, race_id, bib),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        updated += 1
+
+    if updated:
+        _recompute_cat_rankings_for_race(db_path, event_id, race_id)
+    logger.info(
+        "Backfilled %s %s %s: attempted=%d updated=%d",
+        event_code, year, race_id, attempted, updated,
+    )
+    return attempted, updated
+
+
+def _recompute_cat_rankings_for_race(db_path: str, event_id: int, race_id: str) -> None:
+    """Recompute cat_position / full_cat_position for a single race.
+
+    Mirrors ``CSV_to_DB_results.compute_category_rankings`` but scoped to one
+    race so we don't re-rank the whole event every time we backfill a race.
+    """
+    conn = _open(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            WITH RankedResults AS (
+                SELECT race_id, event_id, bib,
+                       RANK() OVER (PARTITION BY race_id, event_id, sex_category
+                                    ORDER BY time) AS cat_rank,
+                       RANK() OVER (PARTITION BY race_id, event_id, full_category
+                                    ORDER BY time) AS full_cat_rank
+                FROM results
+                WHERE full_category NOT LIKE '' AND full_category IS NOT NULL
+                  AND time NOT LIKE '' AND time IS NOT NULL
+                  AND event_id = ? AND race_id = ?
+            )
+            UPDATE results
+            SET cat_position = RankedResults.cat_rank,
+                full_cat_position = RankedResults.full_cat_rank
+            FROM RankedResults
+            WHERE results.race_id = RankedResults.race_id
+              AND results.event_id = RankedResults.event_id
+              AND results.bib = RankedResults.bib
+              AND results.event_id = ?
+              AND results.race_id = ?
+            ''',
+            (event_id, race_id, event_id, race_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def backfill_all(
+    db_path: str,
+    event_ids: Iterable[int] | None = None,
+    threshold: float = DEFAULT_EMPTY_CAT_THRESHOLD,
+) -> None:
+    """Detect + backfill every flagged race.
+
+    Call with ``event_ids`` to restrict the run (used by the loader to touch
+    only what it just updated). Call with no filter for the one-shot.
+    """
+    Database.ensure_cat_backfill_column(db_path)
+    newly = detect_races_needing_backfill(db_path, threshold=threshold)
+    for event_id, race_id, ratio in newly:
+        logger.info(
+            "Flagged for backfill: event_id=%s race_id=%s empty_ratio=%.1f%%",
+            event_id, race_id, ratio * 100,
+        )
+
+    flagged = list_flagged_races(db_path, event_ids=event_ids)
+    if not flagged:
+        logger.info("No flagged races to backfill.")
+        return
+
+    scraper = LiveTrailScraper()
+    total_updated = 0
+    for event_id, race_id, event_code, year in flagged:
+        _, updated = backfill_race(
+            scraper, db_path, event_id, race_id, event_code, year,
+        )
+        total_updated += updated
+    logger.info("Backfill finished: %d row(s) updated across %d race(s)",
+                total_updated, len(flagged))
+
+
+def main() -> None:
+    '''Entry point for the one-shot CLI.'''
+    cfg = get_config()
+    parser = argparse.ArgumentParser(
+        description='Backfill sex/category data for races where '
+                    "LiveTrail's bulk XML is incomplete.",
+    )
+    parser.add_argument('-p', '--path', default=cfg.db_path, help='DB path.')
+    parser.add_argument(
+        '-t', '--threshold', type=float, default=DEFAULT_EMPTY_CAT_THRESHOLD,
+        help=f'Empty-cat ratio that flags a race '
+             f'(default {DEFAULT_EMPTY_CAT_THRESHOLD}).',
+    )
+    parser.add_argument(
+        '--event-id', type=int, action='append',
+        help='Restrict to one or more event_ids (may be repeated).',
+    )
+    args = parser.parse_args()
+    backfill_all(
+        db_path=os.path.abspath(args.path),
+        event_ids=args.event_id,
+        threshold=args.threshold,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/database/loader_LiveTrail/db_LiveTrail_loader.py
+++ b/src/database/loader_LiveTrail/db_LiveTrail_loader.py
@@ -129,6 +129,7 @@ def main(path=None, data_path=None, clean=False, update=False):
         data_path = os.path.join(cfg.data_dir_path, 'csv')
 
     db: Database = Database.create_database(path=path)
+    Database.ensure_cat_backfill_column(db.path)
 
     if clean:
         Database.empty_all_tables(db.path)
@@ -186,6 +187,7 @@ def main(path=None, data_path=None, clean=False, update=False):
                               db=db)
                 event.save_to_database()
 
+    touched_event_ids: set[int] = set()
     for event, name in events.items():
         if event in years:
             for year in years[event]:
@@ -194,6 +196,8 @@ def main(path=None, data_path=None, clean=False, update=False):
                 scraper.set_years([year])
                 cps, cpns = scraper.get_control_points()
                 event_id = Event.get_id_from_code_year(event, year, db=db)
+                if event_id is not None:
+                    touched_event_ids.add(event_id)
                 if not cps:
                     continue
                 races = scraper.get_races()
@@ -260,6 +264,18 @@ def main(path=None, data_path=None, clean=False, update=False):
             script.main(path=os.path.join(actual_path, path), clean=clean,
                         data_path=data_path, update=years)
             
+    # Back-fill sex / category data for races whose bulk XML omits it.
+    # Scoped to touched events so an --update run doesn't re-probe the whole
+    # database every time.
+    if touched_event_ids:
+        try:
+            from database.loader_LiveTrail.backfill_categories import backfill_all
+            logger.info("Running category backfill for %d touched event(s)",
+                         len(touched_event_ids))
+            backfill_all(db_path=db.path, event_ids=touched_event_ids)
+        except Exception:
+            logger.exception("Category backfill failed; continuing")
+
     logger.info("Creating table for enabling AI")
     load_features(db_path=db.path, clean=clean)
     logger.info("Updated events:")

--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -133,6 +133,35 @@ class LiveTrailScraper:
 
         return races_data
 
+    def get_runner_identity(self, event: str, year: str, bib: str) -> dict:
+        '''
+            Fetch the per-runner identity card from coureur.php for a given
+            (event, year, bib). Returns a dict with ``sx`` (H/F/...),
+            ``descat`` (e.g. "0-34", "35-39", "") and ``cat`` (may be "").
+            Returns ``None`` if the request fails or the identite tag is missing.
+        '''
+        for template in (self.base_url, self.base_url2):
+            url = (template.replace("{event}", event).replace("{year}", year)
+                   + f"/coureur.php?rech={bib}")
+            try:
+                response = self._request('GET', url)
+            except requests.RequestException:
+                continue
+            if response is None or response.status_code != 200:
+                continue
+            if '<identite' not in response.text:
+                continue
+            soup = BeautifulSoup(response.text, 'xml')
+            identite = soup.find('identite')
+            if identite is None:
+                continue
+            return {
+                'sx': identite.get('sx', '') or '',
+                'descat': identite.get('descat', '') or '',
+                'cat': identite.get('cat', '') or '',
+            }
+        return None
+
     def _parse_race_info(self, xml_content: str) -> dict:
         # Parse the XML content
         soup = BeautifulSoup(xml_content, 'xml')

--- a/tests/test_backfill_categories.py
+++ b/tests/test_backfill_categories.py
@@ -1,0 +1,195 @@
+'''Tests for the category backfill module.'''
+import os
+import sqlite3
+import unittest
+
+import pytest
+
+from database.create_db import Database
+from database.loader_LiveTrail import backfill_categories
+
+pytestmark = pytest.mark.filterwarnings("ignore", message=".*XMLParsedAsHTMLWarning.*")
+
+
+DB_PATH = 'test_backfill.db'
+
+
+class TestHelpers(unittest.TestCase):
+    def test_sex_category_from_sx(self):
+        self.assertEqual(backfill_categories._sex_category_from_sx('F'), 'Female')
+        self.assertEqual(backfill_categories._sex_category_from_sx('f'), 'Female')
+        self.assertEqual(backfill_categories._sex_category_from_sx('H'), 'Male')
+        self.assertEqual(backfill_categories._sex_category_from_sx('M'), 'Male')
+        self.assertIsNone(backfill_categories._sex_category_from_sx(''))
+        self.assertIsNone(backfill_categories._sex_category_from_sx('Z'))
+        self.assertIsNone(backfill_categories._sex_category_from_sx(None))
+
+    def test_full_category_from_identity_with_descat(self):
+        self.assertEqual(
+            backfill_categories._full_category_from_identity(
+                {'descat': '0-34', 'sx': 'F', 'cat': ''}),
+            '0-34 F',
+        )
+        self.assertEqual(
+            backfill_categories._full_category_from_identity(
+                {'descat': '35-39', 'sx': 'H', 'cat': ''}),
+            '35-39 H',
+        )
+
+    def test_full_category_returns_none_when_descat_empty(self):
+        # Chronic-empty events (seoul100k, 3monestirs, ...) expose sx but no
+        # descat — there's no age bracket to publish so full_category must
+        # stay NULL/empty for the caller to pass through COALESCE.
+        self.assertIsNone(
+            backfill_categories._full_category_from_identity(
+                {'descat': '', 'sx': 'F', 'cat': ''})
+        )
+        self.assertIsNone(
+            backfill_categories._full_category_from_identity(
+                {'descat': '  ', 'sx': 'H', 'cat': ''})
+        )
+
+    def test_full_category_handles_unknown_sex(self):
+        # descat present, sx blank: still publish the age bracket (sex suffix
+        # stripped). Safer than inventing a sex we don't know.
+        self.assertEqual(
+            backfill_categories._full_category_from_identity(
+                {'descat': '0-34', 'sx': '', 'cat': ''}),
+            '0-34',
+        )
+
+
+class TestMigration(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if os.path.exists(DB_PATH):
+            os.remove(DB_PATH)
+        Database.create_database(path=DB_PATH)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(DB_PATH):
+            try:
+                os.remove(DB_PATH)
+            except PermissionError:
+                pass  # Windows file-lock; harmless across test runs
+
+    def test_create_database_includes_cat_needs_backfill(self):
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            cols = {row[1] for row in
+                    conn.execute("PRAGMA table_info(races)").fetchall()}
+        finally:
+            conn.close()
+        self.assertIn('cat_needs_backfill', cols)
+
+    def test_ensure_cat_backfill_column_is_idempotent(self):
+        # Running the migration on a DB that already has the column must not
+        # raise or duplicate the column.
+        Database.ensure_cat_backfill_column(DB_PATH)
+        Database.ensure_cat_backfill_column(DB_PATH)
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            cols = [row[1] for row in
+                    conn.execute("PRAGMA table_info(races)").fetchall()]
+        finally:
+            conn.close()
+        self.assertEqual(cols.count('cat_needs_backfill'), 1)
+
+
+class TestDetector(unittest.TestCase):
+
+    DETECTOR_DB = 'test_backfill_detector.db'
+
+    @classmethod
+    def setUpClass(cls):
+        if os.path.exists(cls.DETECTOR_DB):
+            os.remove(cls.DETECTOR_DB)
+        Database.create_database(path=cls.DETECTOR_DB)
+        conn = sqlite3.connect(cls.DETECTOR_DB)
+        cur = conn.cursor()
+        # Two events, three races, each seeded with different empty-cat rates.
+        cur.executemany(
+            "INSERT INTO events (event_id, code, name, year, country) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [(1, 'utmb', 'UTMB', '2024', 'FR'),
+             (2, 'penyagolosa', 'PENYAGOLOSA', '2026', 'ES')],
+        )
+        cur.executemany(
+            "INSERT INTO races (race_id, event_id, race_name) VALUES (?, ?, ?)",
+            [('utmb', 1, 'UTMB'),
+             ('mim', 2, 'MIM'),
+             ('csp', 2, 'CSP')],
+        )
+        # utmb: 10 rows, 1 empty (10%) — right at the threshold, should flag.
+        # mim:  10 rows, 2 empty (20%) — above threshold, should flag.
+        # csp:  10 rows, 0 empty (0%) — below threshold, should not flag.
+        rows = []
+        for i in range(10):
+            rows.append((
+                'utmb', 1, i + 1, f'{i}', 'U', 'U',
+                '' if i == 0 else '35-39 F',
+                'UTMB', '10:00:00',
+            ))
+            rows.append((
+                'mim', 2, i + 1, f'{i}', 'P', 'P',
+                '' if i < 2 else '35-39 F',
+                'MIM', '10:00:00',
+            ))
+            rows.append((
+                'csp', 2, i + 1, f'{i}', 'C', 'C', '35-39 F',
+                'CSP', '10:00:00',
+            ))
+        cur.executemany(
+            "INSERT INTO results "
+            "(race_id, event_id, position, bib, surname, name, full_category, "
+            "sex_category, time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+        conn.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.DETECTOR_DB):
+            try:
+                os.remove(cls.DETECTOR_DB)
+            except PermissionError:
+                pass
+
+    def test_detect_flags_races_above_threshold(self):
+        flagged = backfill_categories.detect_races_needing_backfill(
+            self.DETECTOR_DB, threshold=0.10,
+        )
+        keys = {(eid, rid) for eid, rid, _ in flagged}
+        # UTMB sits at exactly 10% and should flag; MIM is at 20% and should
+        # flag; CSP is at 0% and must not flag.
+        self.assertIn((1, 'utmb'), keys)
+        self.assertIn((2, 'mim'), keys)
+        self.assertNotIn((2, 'csp'), keys)
+
+    def test_detect_is_idempotent(self):
+        # Re-running the detector returns an empty list because the flag is
+        # already set — the caller uses the returned deltas for logging.
+        backfill_categories.detect_races_needing_backfill(
+            self.DETECTOR_DB, threshold=0.10,
+        )
+        second = backfill_categories.detect_races_needing_backfill(
+            self.DETECTOR_DB, threshold=0.10,
+        )
+        self.assertEqual(second, [])
+
+    def test_list_flagged_races_filters_by_event_id(self):
+        backfill_categories.detect_races_needing_backfill(
+            self.DETECTOR_DB, threshold=0.10,
+        )
+        flagged_event_2 = backfill_categories.list_flagged_races(
+            self.DETECTOR_DB, event_ids=[2],
+        )
+        race_ids = {row[1] for row in flagged_event_2}
+        self.assertEqual(race_ids, {'mim'})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Recovers `sex_category` and (where available) `full_category` for races
where LiveTrail's bulk `passages.php` XML does not serialise the `cat`
attribute on every runner. The data still lives in the per-runner
`coureur.php` endpoint — this PR adds the plumbing to pull it, flag the
affected races, and apply the update both as a one-shot sweep and
automatically during future `--update` loader runs.

## Why

Three distinct clusters of races were losing category data:

- **Spanish 2025+ cluster**: `penyagolosa`, `olladenuria`,
  `epictrailcostadaurada` — stopped publishing the SE / <35 bracket
  from 2025 onward. `coureur.php` still returns both `sx` and `descat`,
  so full category data can be rebuilt.
- **Chronic-empty events** (Asian ultras, MDS-style races,
  mass-participation events — `3monestirs`, `seoul100k`, `tnfkorea`,
  etc.): category attribute has never been published in bulk.
  `coureur.php` returns `sx` but `descat` is blank, so only
  `sex_category` can be recovered (`full_category` stays empty).

Baseline empty-cat rate across the DB sits at 3–6% every year since 2015
— not a LiveTrail-wide regression, it's per-organizer.

## How

1. **Schema** — new `races.cat_needs_backfill` flag (INTEGER DEFAULT 0).
   `Database.ensure_cat_backfill_column` is an idempotent migration for
   existing DBs; `create_database` includes the column for new DBs.
2. **Scraper** — new `LiveTrailScraper.get_runner_identity(event, year, bib)`
   hits `coureur.php?rech=<bib>`, returns `{sx, descat, cat}` or None.
3. **Backfill module** `src/database/loader_LiveTrail/backfill_categories.py`:
   - `detect_races_needing_backfill(threshold=0.1)` scans the DB and
     sets the flag on races whose empty-cat ratio exceeds the threshold.
   - `backfill_race(...)` iterates empty-cat bibs, fetches identity,
     writes `sex_category` directly (H → Male, F → Female) and
     `full_category` as `"{descat} {sx_letter}"` when descat is present,
     then recomputes `cat_position` / `full_cat_position` for the race.
   - `backfill_all(...)` + CLI entry point (`-p`, `-t`, `--event-id`).
4. **Loader integration**:
   - `CSV_to_DB_results.update_category` now skips rows where
     `sex_category IS NOT NULL`, so values written by backfill are not
     clobbered on subsequent loader runs.
   - `db_LiveTrail_loader.main` collects the `event_id`s it touches and
     calls `backfill_all(event_ids=...)` before feature regeneration, so
     `--update` runs auto-backfill only what they just loaded.

## Behaviour verification

Smoke-tested against (penyagolosa 2025 mim, bib 1295):
  - before: `sex_category=NULL`, `full_category=''`, `cat_position=NULL`
  - after:  `sex_category='Female'`, `full_category='0-34 F'`, `cat_position=1`

One-shot sweep over the full DB was executed overnight. Results:
- ~25 races were successfully backfilled (penyagolosa 2025/2026,
  donghaeskyrace, jangsutrailrace, mds*, oxfamtrail, olladenuria, etc.).
- A handful of individual bibs failed after 3/3 HTTP retries due to
  transient DNS / remote-disconnect errors.
- `marxainfantil 2025 marxa` returned identity for only 1 of 1076 bibs
  (that event does not expose per-runner data at all).
- The run eventually crashed on `sqlite3.OperationalError: database is
  locked` — concurrent reader (Streamlit) held a lock. Retry-safe: all
  writes are per-bib, so partial progress is durable. A companion resume
  script is tracked on a separate branch.

## Tests

9 new cases in `tests/test_backfill_categories.py`:
  - sex / full-category derivation helpers (all branches: descat missing,
    descat present, unknown sex)
  - migration idempotency
  - detector threshold behaviour
  - `list_flagged_races` event-id filter

## Usage

```bash
# One-shot sweep over the whole DB (minutes to hours depending on how
# many chronic-empty events need probing):
PYTHONPATH=src python -m database.loader_LiveTrail.backfill_categories \
    --path data/events.db

# Tighten or loosen the flagging threshold:
--threshold 0.5    # only races with >50% empty cat
--threshold 0.05   # catch smaller gaps

# Scope to specific events:
--event-id 12 --event-id 34

# Future loader runs pick up any new/updated events automatically:
python -m database.loader_LiveTrail.db_LiveTrail_loader --update


## Recovery tooling (new)

`scripts/resume_backfill.py` — one-shot, idempotent resume for
interrupted sweeps:
- Parses the prior `backfill.log` for informational context.
- Queries the DB for the **actual** remaining work
  (`sex_category IS NULL` is the authoritative "never processed" signal;
  filtering only on `full_category` would re-hit chronic-empty events).
- Supports `--skip event[:year[:race]]` for races LiveTrail structurally
  can't back (e.g. `--skip marxainfantil:2025`).
- `--dry-run` prints the plan without any HTTP traffic.
- Writes to `backfill_resume.log` so the original log is preserved.

Not auto-invoked anywhere; purely for manual recovery.

Both scripts write `"Backfilled <event> <year> <race>: attempted=N
updated=M"` per race. The main backfill now attaches a FileHandler on
start so `backfill.log` is created automatically (path overridable via
`--log`). The resume helper parses the same format from either
`backfill.log` or `backfill_resume.log`, so chained recoveries (kill,
resume, kill, resume) work without losing state.